### PR TITLE
Drop python3-bloom from ros-dev-tools RPM variant

### DIFF
--- a/ros-build-essential/ros-build-essential.control
+++ b/ros-build-essential/ros-build-essential.control
@@ -4,7 +4,7 @@ Homepage: https://github.com/ros-infrastructure/infra-variants
 Standards-Version: 3.9.2
 
 Package: ros-build-essential
-Version: 1.0.1
+Version: 1.0.2
 Maintainer: Steven! Ragnarök <steven@openrobotics.org>
 Depends:
  build-essential,

--- a/ros-build-essential/ros-build-essential.spec
+++ b/ros-build-essential/ros-build-essential.spec
@@ -1,5 +1,5 @@
 Name: ros-build-essential
-Version: 1.0.1
+Version: 1.0.2
 Summary: Packages expected when building any ROS package
 Release: 1%{?dist}%{?release_suffix}
 BuildArch: noarch
@@ -57,6 +57,9 @@ cp -a %{SOURCE0} %{SOURCE1} .
 %license copyright
 
 %changelog
+* Fri May 15 2026 Scott K Logan - 1.0.2-1
+- Drop python3-bloom from ros-dev-tools variant
+
 * Tue Apr 23 2024 Scott K Logan - 1.0.1-1
 - Add python3-colcon-mixin to ros-dev-tools variant
 

--- a/ros-dev-tools/ros-dev-tools.control
+++ b/ros-dev-tools/ros-dev-tools.control
@@ -4,7 +4,7 @@ Homepage: https://github.com/ros-infrastructure/infra-variants
 Standards-Version: 3.9.2
 
 Package: ros-dev-tools
-Version: 1.0.1
+Version: 1.0.2
 Maintainer: Steven! Ragnarök <steven@openrobotics.org>
 Depends:
  ros-build-essential,

--- a/ros-dev-tools/ros-dev-tools.spec
+++ b/ros-dev-tools/ros-dev-tools.spec
@@ -1,5 +1,5 @@
 Name: ros-dev-tools
-Version: 1.0.1
+Version: 1.0.2
 Summary: Developer Tools for ROS
 Release: 1%{?dist}%{?release_suffix}
 BuildArch: noarch
@@ -8,7 +8,8 @@ URL: https://github.com/ros-infrastructure/infra-variants
 Source0: README.md
 Source1: copyright
 Requires: ros-build-essential
-Requires: python3-bloom
+# Bloom is not currently supported in Fedora/EPEL due to vcstools
+# Requires: python3-bloom
 Requires: python3-colcon-common-extensions
 Requires: python3-colcon-mixin
 Requires: python3-rosdep
@@ -30,6 +31,9 @@ cp -a %{SOURCE0} %{SOURCE1} .
 %license copyright
 
 %changelog
+* Fri May 15 2026 Scott K Logan - 1.0.2-1
+- Drop python3-bloom from ros-dev-tools variant
+
 * Tue Apr 23 2024 Scott K Logan - 1.0.1-1
 - Add python3-colcon-mixin to ros-dev-tools variant
 


### PR DESCRIPTION
This package has never worked due to the lack of bloom, and I think we should stop waiting for that to materialize.